### PR TITLE
Add end-to-end tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,12 +132,12 @@ jobs:
             export TF_VAR_save_image_metadata_lambda_filename=/tmp/workspace/packages/public-image-details/dist/save-image-metadata.zip
             terragrunt apply-all --terragrunt-non-interactive -auto-approve
 
-            terragrunt-output-to-env.sh aws_region private_url subscribed_topic_arn >> ../../env.outputs
+            terragrunt-output-to-env.sh aws_region private_url subscribed_topic_arn >> ../../env.public_image_details.outputs
           working_directory: terraform/environments/
       - persist_to_workspace:
           root: ~/repo
           paths:
-            - terraform/environments/env.outputs
+            - terraform/environments/env.public_image_details.outputs
 
   test_integration_public_image_details:
     executor: node-build-environment
@@ -149,8 +149,8 @@ jobs:
       - run:
           name: Integration tests
           command: |
-            source /tmp/workspace/terraform/environments/env.outputs
-            cat /tmp/workspace/terraform/environments/env.outputs
+            source /tmp/workspace/terraform/environments/env.public_image_details.outputs
+            cat /tmp/workspace/terraform/environments/env.public_image_details.outputs
 
             yarn test:integration --scope public-image-details
 
@@ -198,12 +198,12 @@ jobs:
             export TF_VAR_new_image_event_producer_lambda_filename=/tmp/workspace/packages/public-image-store/dist/public-image-store.zip
             terragrunt apply-all --terragrunt-non-interactive -auto-approve
 
-            terragrunt-output-to-env.sh aws_region subscribed_topic_arn bucket_name >> ../../env.outputs
+            terragrunt-output-to-env.sh aws_region subscribed_topic_arn bucket_name >> ../../env.public_image_store.outputs
           working_directory: terraform/environments/
       - persist_to_workspace:
           root: ~/repo
           paths:
-            - terraform/environments/env.outputs
+            - terraform/environments/env.public_image_store.outputs
 
   test_integration_public_image_store:
     executor: node-build-environment
@@ -215,16 +215,30 @@ jobs:
       - run:
           name: Integration tests
           command: |
-            source /tmp/workspace/terraform/environments/env.outputs
-            cat /tmp/workspace/terraform/environments/env.outputs
+            source /tmp/workspace/terraform/environments/env.public_image_store.outputs
+            cat /tmp/workspace/terraform/environments/env.public_image_store.outputs
 
             yarn test:integration --scope public-image-store
+
+  ## End to End Tests
+
+  end_to_end_test:
+    executor: node-build-environment
+    steps:
+      - checkout
+      - yarn-install-with-cache
+      - run:
+          name: Test
+          command: yarn test:e2e
 
 workflows:
   version: 2
 
-  website:
+  test_build_it_e2e_all_services:
     jobs:
+
+      ## Website
+
       - test_website
       - build_website:
           requires:
@@ -233,8 +247,8 @@ workflows:
           requires:
             - build_website
 
-  public_image_details:
-    jobs:
+      ## Public Image Details
+
       - test_public_image_details
       - build_public_image_details:
           requires:
@@ -250,8 +264,8 @@ workflows:
               ignore:
                 - master
 
-  public_image_store:
-    jobs:
+      ## Public Image Store
+
       - test_public_image_store
       - build_public_image_store:
           requires:
@@ -262,6 +276,18 @@ workflows:
       - test_integration_public_image_store:
           requires:
             - deploy_public_image_store
+          filters:
+            branches:
+              ignore:
+                - master
+
+      ## End to End Tests
+
+      - end_to_end_test:
+          requires:
+            - deploy_website
+            - test_integration_public_image_details
+            - test_integration_public_image_store
           filters:
             branches:
               ignore:

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "lerna run test --stream",
     "test:integration": "lerna run test:integration --stream",
     "test:upload-coverage": "lerna run test:upload-coverage --stream",
+    "test:e2e" : "lerna run test:e2e --scope e2e --stream",
     "build": "lerna run build --stream"
   }
 }

--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -1,0 +1,5 @@
+# Public Image Details Service
+
+Provides details about images that are publicly available on the platform.
+
+![Serverless architecture for service](docs/architecture.jpg)

--- a/packages/e2e/jest.config.js
+++ b/packages/e2e/jest.config.js
@@ -1,0 +1,25 @@
+module.exports = {
+  globals: {
+    "ts-jest": {
+      tsConfigFile: "./tsconfig.json",
+    },
+  },
+  transform: {
+    "^.+\\.tsx?$": "ts-jest",
+  },
+  testRegex: "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
+  moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
+  testEnvironment: "node",
+  collectCoverage: false,
+  reporters: [
+    "default",
+    [
+      "jest-junit",
+      {
+        suiteName: "jest tests",
+        outputDirectory: "reports/jest/",
+        outputName: "js-test-results.xml",
+      },
+    ],
+  ],
+};

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "e2e",
+  "version": "1.0.0",
+  "private": true,
+  "devDependencies": {
+    "@types/jest": "^23.3.1",
+    "@types/node": "^10.9.4",
+    "jest": "^23.6.0",
+    "jest-junit": "^6.0.0",
+    "prettier": "^1.15.3",
+    "ts-jest": "<23.10.0",
+    "ts-loader": "^4.5.0",
+    "tslint": "^5.11.0",
+    "tslint-config-prettier": "^1.17.0",
+    "typescript": "^3.0.1"
+  },
+  "scripts": {
+    "lint:fix": "tslint --fix -c tslint.json '{src,test}/**/*.ts'",
+    "lint": "tslint -c tslint.json '{src,test}/**/*.ts'",
+    "test:e2e": "jest test/"
+  }
+}

--- a/packages/e2e/test/integration.spec.ts
+++ b/packages/e2e/test/integration.spec.ts
@@ -1,0 +1,5 @@
+describe("End to end tests", () => {
+  it("Image Details API returns public URL for uploaded image", () => {
+    expect(1).toBe(1);
+  });
+});

--- a/packages/e2e/tsconfig.json
+++ b/packages/e2e/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "module": "commonjs",
+    "target": "es2018",
+    "sourceMap": false,
+    "esModuleInterop": true,
+    "lib": ["es2018", "esnext.asynciterable"],
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/packages/e2e/tslint.json
+++ b/packages/e2e/tslint.json
@@ -1,0 +1,9 @@
+{
+    "extends": [
+        "tslint:recommended",
+        "tslint-config-prettier"
+    ],
+    "rules": {
+        "object-literal-sort-keys": false
+    }
+}


### PR DESCRIPTION
In order to add end-to-end tests at the end of the CI process I had to move away from workspaces into jobs.